### PR TITLE
Only Owner setRatesCalculator + setBorrowersRegistry

### DIFF
--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -34,10 +34,11 @@ contract Pool is Ownable {
 
     /**
      * Sets the new rate calculator
-     * The calculator is an external contract that contains the logic for calculating deposit and borrowing rates
+     * The calculator is an external contract that contains the logic for calculating deposit and borrowing rates.
+     * Only the owner of the Contract can execute this funciton
      * @dev _ratesCalculator the address of rates calculator
     **/
-    function setRatesCalculator(IRatesCalculator _ratesCalculator) public {
+    function setRatesCalculator(IRatesCalculator _ratesCalculator) public onlyOwner {
         require(address(_ratesCalculator) != address(0), "The rates calculator cannot set to a null address");
 
         ratesCalculator = _ratesCalculator;
@@ -47,10 +48,11 @@ contract Pool is Ownable {
 
     /**
      * Sets the new rate calculator
-     * The borrowers registry decides if an account can borrow funds
+     * The borrowers registry decides if an account can borrow funds. Only the owner of the Contract can
+     * execute this funciton
      * @dev _borrowersRegistry the address of borrowers registry
     **/
-    function setBorrowersRegistry(IBorrowersRegistry _borrowersRegistry) public {
+    function setBorrowersRegistry(IBorrowersRegistry _borrowersRegistry) public onlyOwner {
       require(address(_borrowersRegistry) != address(0), "The borrowers registry cannot set to a null address");
 
       borrowersRegistry = _borrowersRegistry;


### PR DESCRIPTION
This PR Add onlyOwner to setter functions inside as `Pool`. This prevents anyone from being able to set the rates or borrow registry logic, now only the owner of the Pool can do this. 